### PR TITLE
build: bump `vercel-php` from 0.5.1 to 0.5.2

### DIFF
--- a/platform/Vercel.php
+++ b/platform/Vercel.php
@@ -322,7 +322,7 @@ function VercelUpdate($appId, $token, $sourcePath = "")
     $data["target"] = "production";
     $data["routes"][0]["src"] = "/(.*)";
     $data["routes"][0]["dest"] = "/api/index.php";
-    $data["functions"]["api/index.php"]["runtime"] = "vercel-php@0.5.1";
+    $data["functions"]["api/index.php"]["runtime"] = "vercel-php@0.5.2";
     if ($sourcePath=="") $sourcePath = splitlast(splitlast(__DIR__, "/")[0], "/")[0];
     //echo $sourcePath . "<br>";
     getEachFiles($file, $sourcePath);


### PR DESCRIPTION
`vercel-php@0.5.2` 将 Node.js 更新到了 14.x (详见 [CHANGELOG.md](https://github.com/vercel-community/php/blob/master/CHANGELOG.md#052---2022-08-10)).

fix #632