### PR TITLE
bugfix: server cannot download from OneDrive due to 302

### DIFF
--- a/common.php
+++ b/common.php
@@ -2310,11 +2310,7 @@ function render_list($path = '', $files = [])
         } else {
             if (!($html = getcache('customTheme'))) {
                 $file_path = $theme;
-                $tmp = curl('GET', $file_path, '', [], 1);
-                if ($tmp['stat']==302) {
-                    error_log1(json_encode($tmp));
-                    $tmp = curl('GET', $tmp["returnhead"]["location"]);
-                }
+                $tmp = curl('GET', $file_path, '', [], 0, 1);
                 if (!!$tmp['body']) $html = $tmp['body'];
                 savecache('customTheme', $html, '', 9999);
             }

--- a/common.php
+++ b/common.php
@@ -2313,7 +2313,7 @@ function render_list($path = '', $files = [])
                 $tmp = curl('GET', $file_path, '', [], 1);
                 if ($tmp['stat']==302) {
                     error_log1(json_encode($tmp));
-                    $tmp = curl('GET', $tmp["returnhead"]["Location"]);
+                    $tmp = curl('GET', $tmp["returnhead"]["location"]);
                 }
                 if (!!$tmp['body']) $html = $tmp['body'];
                 savecache('customTheme', $html, '', 9999);

--- a/disk/Onedrive.php
+++ b/disk/Onedrive.php
@@ -121,7 +121,10 @@ class Onedrive {
                     if (in_array(strtolower(splitlast($files['name'],'.')[1]), $exts['txt'])) {
                         if ($files['size']<1024*1024) {
                             if (!(isset($files['content'])&&$files['content']['stat']==200)) {
-                                $content1 = curl('GET', $files[$this->DownurlStrName]);
+                                $content1 = curl('GET', $files[$this->DownurlStrName], '', [], 1);
+                                if ($content1['stat'] == 302) {
+                                    $content1 = curl('GET', $content1["returnhead"]["location"]);
+                                }
                                 $tmp = null;
                                 $tmp = json_decode(json_encode($content1), true);
                                 if ($tmp['body']===null) {

--- a/disk/Onedrive.php
+++ b/disk/Onedrive.php
@@ -62,7 +62,7 @@ class Onedrive {
                             //savecache('path_' . $parentpath, $parentfiles, $this->disktag);
                             if ($parentfiles['children'][$filename]['size']<1024*1024) {
                                 if (!(isset($parentfiles['children'][$filename]['content'])&&$parentfiles['children'][$filename]['content']['stat']==200)) {
-                                    $content1 = curl('GET', $parentfiles['children'][$filename][$this->DownurlStrName]);
+                                    $content1 = curl('GET', $parentfiles['children'][$filename][$this->DownurlStrName], '', [], 0, 1);
                                     $tmp = null;
                                     $tmp = json_decode(json_encode($content1), true);
                                     if ($tmp['body']===null) {
@@ -121,10 +121,7 @@ class Onedrive {
                     if (in_array(strtolower(splitlast($files['name'],'.')[1]), $exts['txt'])) {
                         if ($files['size']<1024*1024) {
                             if (!(isset($files['content'])&&$files['content']['stat']==200)) {
-                                $content1 = curl('GET', $files[$this->DownurlStrName], '', [], 1);
-                                if ($content1['stat'] == 302) {
-                                    $content1 = curl('GET', $content1["returnhead"]["location"]);
-                                }
+                                $content1 = curl('GET', $files[$this->DownurlStrName], '', [], 0, 1);
                                 $tmp = null;
                                 $tmp = json_decode(json_encode($content1), true);
                                 if ($tmp['body']===null) {


### PR DESCRIPTION
Onedrive 返回的"直链"有时候也是302，需要redirect，否则内容是空的（比如head.omf和文本文件预览都没办法显示）
另外，["returnhead"]["Location"]好像不存在，虽然我基本不懂PHP，但是我感觉键值应该是大小写敏感的。反正改成location就能用了。请检查一下是不是这样