### PR TITLE
fix: allow brackets and spaces in url for apache server

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -3,7 +3,7 @@
 # # AllowOverride All
 RewriteEngine On
 # RewriteCond $1 !^(.well-known)
-RewriteRule ^(.*) index.php?/$1 [L]
+RewriteRule ^(.*) index.php [QSA,L]
 
 ###-----------------------------------
 ### nginx


### PR DESCRIPTION
When url contains brackets or spaces, apache server get Error like below and return 403: 
Rewritten query string contains control characters or spaces

I don't know why firefox not escape `[` and `]`, but when I use `[QSA]` instead of adding patterns to `index.php?` directly, the problem gone.